### PR TITLE
Shrink container size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-RUN apk add openjdk21-jre-headless jq curl
+RUN apk add --no-cache openjdk21-jre-headless jq curl
 
 WORKDIR /minecraft-server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 FROM alpine:latest
-RUN apk add --no-cache openjdk21-jre-headless jq curl
+RUN apk add --no-cache openjdk21-jre-headless
 
 WORKDIR /minecraft-server
 
-RUN API_URL="https://api.papermc.io/v2/projects/paper" && \
+RUN apk add --no-cache jq curl && \
+    API_URL="https://api.papermc.io/v2/projects/paper" && \
     VERSION=$(curl -s $API_URL | jq -r '.versions | last') && \
     BUILD=$(curl -s $API_URL/versions/$VERSION | jq -r '.builds | last') && \
     JAR_NAME="paper-$VERSION-$BUILD.jar" && \
-    curl -o paper.jar -L "$API_URL/versions/$VERSION/builds/$BUILD/downloads/$JAR_NAME"
+    curl -o paper.jar -L "$API_URL/versions/$VERSION/builds/$BUILD/downloads/$JAR_NAME" && \
+    apk del --no-cache jq curl
 
 RUN echo "eula=true" > eula.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-RUN apk add openjdk21 jq curl
+RUN apk add openjdk21-jre-headless jq curl
 
 WORKDIR /minecraft-server
 


### PR DESCRIPTION
This PR reduces the Docker image size from **384.1MB** to **261.4MB** (**~123MB savings**) through three key optimizations:

1. Switch to lightweight Java runtime: Replace openjdk21 with openjdk21-jre-headless (saves **~114MB**)
2. Remove APK package cache: Add --no-cache flag to prevent caching downloaded packages (saves **~3MB**)
3. Clean up build dependencies: Install and remove jq and curl in single RUN layer after downloading PaperMC server (saves **~6MB**)